### PR TITLE
Added GDPR fields to subscribe endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,17 @@ Add a new subscriber or update an existing one.
 
 Pass these along as query string parameters on your endpoint.
 
-| Parameter       | Description                                 | Value   | Example              | Required |
-|-----------------|---------------------------------------------|---------|----------------------|----------|
-| `email`         | The subscriber email address                | String  | `hi@there.com`       | Yes      |
-| `merge`         | Any merge tags to add (ex `FNAME`)          | String  | `merge[FNAME]=chris` | No       |
-| `group`         | Any interest groups to add                  | Boolean | `group[1234]=1`      | No       |
-| `tag`           | Any tags to add                             | Boolean | `tag[5678]=1`        | No       |
-| `<Form Key>`    | `<Form Secret>` (from your settings)        | String  | `1234=abcdef`        | No       |
-| `<Honeypot>`    | A honeypot value if enabled in settings     | String  | `     `              | No       |
-| `do-not-create` | Only update existing user, do not subscribe | Boolean | `1`                  | No       |
-| `u`             | Remove user from provided interest groups   | Boolean | `1`                  | No       |
+| Parameter       | Description                                       | Value   | Example              | Required |
+|-----------------|---------------------------------------------------|---------|----------------------|----------|
+| `email`         | The subscriber email address                      | String  | `hi@there.com`       | Yes      |
+| `merge`         | Any merge tags to add (ex `FNAME`)                | String  | `merge[FNAME]=chris` | No       |
+| `group`         | Any interest groups to add                        | Boolean | `group[1234]=1`      | No       |
+| `marketing`     | Any marketing fields to set (from settings page)  | Boolean | `marketing[1a3b4]=1` | No       |
+| `tag`           | Any tags to add                                   | Boolean | `tag[5678]=1`        | No       |
+| `<Form Key>`    | `<Form Secret>` (from your settings)              | String  | `1234=abcdef`        | No       |
+| `<Honeypot>`    | A honeypot value if enabled in settings           | String  | `     `              | No       |
+| `do-not-create` | Only update existing user, do not subscribe       | Boolean | `1`                  | No       |
+| `u`             | Remove user from provided interest groups         | Boolean | `1`                  | No       |
 
 **Sample API Calls**
 


### PR DESCRIPTION
I added the possibility to send the marketing fields to the plugin endpoint so it sends them to mailchimp.

The main struggle regarding marketing fields is to get the ID of each field. For that I added them in the plugin settings screen. The Main problem es that, for getting those fields, the list has to have, at least, one member. I'm subscribing (and after deleting) a dummy member to the list if it is empty to get those fields, but that is done every time yo access the settings screen.

A good improvement would be to store those settings in the plugin options, but I don't have time now for adding that. If you don't accept the PR because of that I'll understand it. Probable in a week or so I'll have more time to make that improvement.

Solves https://github.com/cferdinandi/gmt-mailchimp-wp-rest-api/issues/1